### PR TITLE
refactor(main): remove exception-handler duplication with a data-driven mapping (DRY/OCP)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -186,3 +186,11 @@ All errors are returned as [RFC 9457 Problem Details](https://www.rfc-editor.org
 `Content-Type: application/problem+json`. This provides a consistent, machine-readable error format.
 Each error body includes a `code` field (snake_case) in addition to the standard `type`, `title`,
 `status`, and `detail` fields to make programmatic handling easy without parsing URIs.
+
+Domain errors carry their own HTTP mapping. Each subclasses `DomainError` (in `errors.py`) and
+declares its `status`, `code` and `title` as class attributes; `detail` defaults to the exception
+message but can be overridden for a fixed, message-independent explanation. A single generic handler
+in `main.py` (`_domain_error_handler`) resolves *any* `DomainError` via the exception's MRO and calls
+`to_problem_detail()`, so introducing a new domain error never requires editing the web layer. Only
+the genuinely distinct cases keep dedicated handlers: `HTTPException`, `RequestValidationError`, and
+the `Exception` catch-all.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -187,8 +187,9 @@ All errors are returned as [RFC 9457 Problem Details](https://www.rfc-editor.org
 Each error body includes a `code` field (snake_case) in addition to the standard `type`, `title`,
 `status`, and `detail` fields to make programmatic handling easy without parsing URIs.
 
-Domain errors carry their own HTTP mapping. Each subclasses `DomainError` (in `errors.py`) and
-declares its `status`, `code` and `title` as class attributes; `detail` defaults to the exception
+Domain errors carry their own HTTP mapping. Each domain error subclasses `DomainError` (in
+`errors.py`) and declares its `status`, `code` and `title` as class attributes; `detail` defaults to
+the exception
 message but can be overridden for a fixed, message-independent explanation. A single generic handler
 in `main.py` (`_domain_error_handler`) resolves *any* `DomainError` via the exception's MRO and calls
 `to_problem_detail()`, so introducing a new domain error never requires editing the web layer. Only

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,9 +189,8 @@ Each error body includes a `code` field (snake_case) in addition to the standard
 
 Domain errors carry their own HTTP mapping. Each domain error subclasses `DomainError` (in
 `errors.py`) and declares its `status`, `code` and `title` as class attributes; `detail` defaults to
-the exception
-message but can be overridden for a fixed, message-independent explanation. A single generic handler
-in `main.py` (`_domain_error_handler`) resolves *any* `DomainError` via the exception's MRO and calls
-`to_problem_detail()`, so introducing a new domain error never requires editing the web layer. Only
-the genuinely distinct cases keep dedicated handlers: `HTTPException`, `RequestValidationError`, and
-the `Exception` catch-all.
+the exception message but can be overridden for a fixed, message-independent explanation. A single
+generic handler in `main.py` (`_domain_error_handler`) resolves *any* `DomainError` via the
+exception's MRO and calls `to_problem_detail()`, so introducing a new domain error never requires
+editing the web layer. Only the genuinely distinct cases keep dedicated handlers: `HTTPException`,
+`RequestValidationError`, and the `Exception` catch-all.

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 from starlette.applications import Starlette
 from starlette.routing import Route
 
-from tr_bridge.errors import ProblemDetail, problem_response
+from tr_bridge.errors import DomainError, ProblemDetail, problem_response
 
 
 def _make_app(detail: ProblemDetail) -> Starlette:
@@ -95,3 +95,33 @@ class TestProblemResponse:
         assert body["title"] == "Internal error"
         assert body["detail"] == "Unexpected failure."
         assert "type" in body
+
+
+class TestDomainError:
+    def test_to_problem_detail_uses_class_metadata_and_message(self) -> None:
+        class SampleError(DomainError):
+            status = 418
+            code = "sample_error"
+            title = "Sample error"
+
+        problem = SampleError("something went wrong").to_problem_detail()
+
+        assert problem.status == 418
+        assert problem.code == "sample_error"
+        assert problem.title == "Sample error"
+        assert problem.detail == "something went wrong"
+        assert problem.type == "https://tr-bridge/errors/sample-error"
+
+    def test_detail_can_be_overridden_independently_of_message(self) -> None:
+        class FixedDetailError(DomainError):
+            status = 409
+            code = "fixed_detail"
+            title = "Fixed detail"
+
+            @property
+            def detail(self) -> str:
+                return "a fixed, message-independent explanation"
+
+        problem = FixedDetailError("internal message").to_problem_detail()
+
+        assert problem.detail == "a fixed, message-independent explanation"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,6 @@
 """Tests for tr_bridge.errors — RFC 9457 Problem Details helpers."""
 
+import pytest
 from fastapi.testclient import TestClient
 from starlette.applications import Starlette
 from starlette.routing import Route
@@ -125,3 +126,26 @@ class TestDomainError:
         problem = FixedDetailError("internal message").to_problem_detail()
 
         assert problem.detail == "a fixed, message-independent explanation"
+
+    def test_subclass_missing_required_attribute_fails_fast(self) -> None:
+        """A subclass that forgets status/code/title must fail at definition time."""
+        with pytest.raises(TypeError, match="must define"):
+
+            class BrokenError(DomainError):
+                code = "broken"
+                title = "Broken"
+                # 'status' intentionally omitted
+
+    def test_subclass_may_inherit_required_attributes_from_parent(self) -> None:
+        """Intermediate subclasses may inherit the mapping without redeclaring it."""
+
+        class ParentError(DomainError):
+            status = 409
+            code = "parent"
+            title = "Parent"
+
+        class ChildError(ParentError):
+            code = "child"
+
+        assert ChildError("boom").to_problem_detail().status == 409
+        assert ChildError("boom").to_problem_detail().code == "child"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -326,13 +326,9 @@ class TestDomainExceptionHandlers:
     def _make_app_with_handlers(self) -> "FastAPI":
         from fastapi import FastAPI
 
+        from tr_bridge.errors import DomainError
         from tr_bridge.instance_registry import InstanceNotFoundError
-        from tr_bridge.main import (
-            _code_rejected_handler,
-            _instance_not_found_handler,
-            _invalid_state_handler,
-            _login_in_progress_handler,
-        )
+        from tr_bridge.main import _domain_error_handler
         from tr_bridge.session import (
             CodeRejectedError,
             InvalidStateError,
@@ -341,12 +337,8 @@ class TestDomainExceptionHandlers:
         )
 
         test_app = FastAPI()
-        test_app.add_exception_handler(
-            InstanceNotFoundError, _instance_not_found_handler
-        )
-        test_app.add_exception_handler(LoginInProgressError, _login_in_progress_handler)
-        test_app.add_exception_handler(CodeRejectedError, _code_rejected_handler)
-        test_app.add_exception_handler(InvalidStateError, _invalid_state_handler)
+        # A single generic handler covers every domain error via the MRO.
+        test_app.add_exception_handler(DomainError, _domain_error_handler)
 
         @test_app.get("/_not_found")
         async def _raise_not_found():

--- a/tr_bridge/errors.py
+++ b/tr_bridge/errors.py
@@ -1,5 +1,7 @@
 """RFC 9457 Problem Details — error model and response helper."""
 
+from typing import ClassVar
+
 from pydantic import BaseModel, model_validator
 from starlette.responses import Response
 
@@ -21,6 +23,37 @@ class ProblemDetail(BaseModel):
             slug = self.code.replace("_", "-")
             self.type = f"{_BASE_TYPE_URL}/{slug}"
         return self
+
+
+class DomainError(Exception):
+    """Base class for domain errors carrying their own HTTP/Problem metadata.
+
+    Subclasses declare the RFC 9457 mapping as class attributes (``status``,
+    ``code``, ``title``). A single generic exception handler can then translate
+    *any* :class:`DomainError` into a :class:`ProblemDetail`, so adding a new
+    domain error never requires touching the web layer's handler wiring.
+
+    The ``detail`` field defaults to ``str(self)``; subclasses may override the
+    :attr:`detail` property when a fixed, message-independent detail is desired.
+    """
+
+    status: ClassVar[int]
+    code: ClassVar[str]
+    title: ClassVar[str]
+
+    @property
+    def detail(self) -> str:
+        """Human-readable explanation; defaults to the exception message."""
+        return str(self)
+
+    def to_problem_detail(self) -> ProblemDetail:
+        """Render this error as an RFC 9457 :class:`ProblemDetail`."""
+        return ProblemDetail(
+            status=self.status,
+            code=self.code,
+            title=self.title,
+            detail=self.detail,
+        )
 
 
 def problem_response(detail: ProblemDetail) -> Response:

--- a/tr_bridge/errors.py
+++ b/tr_bridge/errors.py
@@ -41,6 +41,24 @@ class DomainError(Exception):
     code: ClassVar[str]
     title: ClassVar[str]
 
+    _REQUIRED_ATTRS: ClassVar[tuple[str, ...]] = ("status", "code", "title")
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        """Fail fast when a subclass omits a required Problem-mapping attribute.
+
+        Attributes may be inherited from an intermediate ``DomainError`` parent,
+        so the check looks them up on the class (not just its own ``__dict__``).
+        This prevents a misconfigured error from silently degrading to the 500
+        catch-all handler at request time.
+        """
+        super().__init_subclass__(**kwargs)
+        missing = [attr for attr in cls._REQUIRED_ATTRS if not hasattr(cls, attr)]
+        if missing:
+            raise TypeError(
+                f"{cls.__name__} must define {', '.join(missing)} "
+                f"as class attribute(s)."
+            )
+
     @property
     def detail(self) -> str:
         """Human-readable explanation; defaults to the exception message."""

--- a/tr_bridge/instance_registry.py
+++ b/tr_bridge/instance_registry.py
@@ -6,17 +6,26 @@ import asyncio
 import logging
 
 from tr_bridge.config import Config
+from tr_bridge.errors import DomainError
 from tr_bridge.session import InstanceSession
 
 logger = logging.getLogger(__name__)
 
 
-class InstanceNotFoundError(Exception):
+class InstanceNotFoundError(DomainError):
     """Raised when a requested instance name is not in the registry."""
+
+    status = 404
+    code = "instance_not_found"
+    title = "Instance not found"
 
     def __init__(self, name: str) -> None:
         super().__init__(f"Instance not found: {name!r}")
         self.name = name
+
+    @property
+    def detail(self) -> str:
+        return f"No instance named {self.name!r} is configured."
 
 
 class InstanceRegistry:

--- a/tr_bridge/main.py
+++ b/tr_bridge/main.py
@@ -18,25 +18,20 @@ from starlette.exceptions import HTTPException
 
 from tr_bridge.auth import UnauthorizedException, check_api_key
 from tr_bridge.config import Config
-from tr_bridge.errors import ProblemDetail, problem_response
-from tr_bridge.instance_registry import InstanceNotFoundError, InstanceRegistry
-from tr_bridge.session import (
-    CodeRejectedError,
-    InvalidStateError,
-    LoginInProgressError,
-    NoLoginPendingError,
-    RateLimitedError,
-    SessionExpiredError,
-    TrUpstreamError,
-)
+from tr_bridge.errors import DomainError, ProblemDetail, problem_response
+from tr_bridge.instance_registry import InstanceRegistry
 
 logger = logging.getLogger(__name__)
 
 _VERSION_FILE = Path(__file__).parent.parent / "VERSION"
 
 
-class InvalidRequestError(Exception):
+class InvalidRequestError(DomainError):
     """Raised when a request carries missing or malformed query parameters."""
+
+    status = 400
+    code = "invalid_request"
+    title = "Invalid request"
 
 
 # Paths that bypass API-key authentication.
@@ -143,124 +138,16 @@ async def _unhandled_exception_handler(request: Request, exc: Exception) -> Resp
     )
 
 
-@app.exception_handler(InstanceNotFoundError)
-async def _instance_not_found_handler(
-    request: Request, exc: InstanceNotFoundError
-) -> Response:
-    return problem_response(
-        ProblemDetail(
-            status=404,
-            code="instance_not_found",
-            title="Instance not found",
-            detail=f"No instance named {exc.name!r} is configured.",
-        )
-    )
+@app.exception_handler(DomainError)
+async def _domain_error_handler(request: Request, exc: DomainError) -> Response:
+    """Translate any :class:`DomainError` into its RFC 9457 Problem Details.
 
-
-@app.exception_handler(LoginInProgressError)
-async def _login_in_progress_handler(
-    request: Request, exc: LoginInProgressError
-) -> Response:
-    return problem_response(
-        ProblemDetail(
-            status=409,
-            code="login_in_progress",
-            title="Login already in progress",
-            detail=str(exc),
-        )
-    )
-
-
-@app.exception_handler(CodeRejectedError)
-async def _code_rejected_handler(request: Request, exc: CodeRejectedError) -> Response:
-    return problem_response(
-        ProblemDetail(
-            status=401,
-            code="code_rejected",
-            title="2FA code rejected",
-            detail=str(exc),
-        )
-    )
-
-
-@app.exception_handler(InvalidStateError)
-async def _invalid_state_handler(request: Request, exc: InvalidStateError) -> Response:
-    return problem_response(
-        ProblemDetail(
-            status=409,
-            code="invalid_state",
-            title="Operation not valid in current state",
-            detail=str(exc),
-        )
-    )
-
-
-@app.exception_handler(NoLoginPendingError)
-async def _no_login_pending_handler(
-    request: Request, exc: NoLoginPendingError
-) -> Response:
-    return problem_response(
-        ProblemDetail(
-            status=409,
-            code="no_login_pending",
-            title="No login pending",
-            detail="No login is awaiting a 2FA code; start a login first.",
-        )
-    )
-
-
-@app.exception_handler(RateLimitedError)
-async def _rate_limited_handler(request: Request, exc: RateLimitedError) -> Response:
-    return problem_response(
-        ProblemDetail(
-            status=429,
-            code="rate_limited",
-            title="Rate limited",
-            detail=str(exc),
-        )
-    )
-
-
-@app.exception_handler(TrUpstreamError)
-async def _tr_upstream_error_handler(
-    request: Request, exc: TrUpstreamError
-) -> Response:
-    return problem_response(
-        ProblemDetail(
-            status=502,
-            code="tr_upstream_error",
-            title="Trade Republic upstream error",
-            detail=str(exc),
-        )
-    )
-
-
-@app.exception_handler(SessionExpiredError)
-async def _session_expired_handler(
-    request: Request, exc: SessionExpiredError
-) -> Response:
-    return problem_response(
-        ProblemDetail(
-            status=401,
-            code="session_expired",
-            title="Session expired",
-            detail=str(exc),
-        )
-    )
-
-
-@app.exception_handler(InvalidRequestError)
-async def _invalid_request_handler(
-    request: Request, exc: InvalidRequestError
-) -> Response:
-    return problem_response(
-        ProblemDetail(
-            status=400,
-            code="invalid_request",
-            title="Invalid request",
-            detail=str(exc),
-        )
-    )
+    A single data-driven handler covers every domain exception: the HTTP
+    ``status``, ``code`` and ``title`` live on the exception class itself, so
+    introducing a new domain error requires no change here. Starlette resolves
+    this handler for subclasses via the exception's MRO.
+    """
+    return problem_response(exc.to_problem_detail())
 
 
 # ---------------------------------------------------------------------------

--- a/tr_bridge/session.py
+++ b/tr_bridge/session.py
@@ -23,6 +23,7 @@ from pytr.api import TradeRepublicApi
 from pytr.timeline import Timeline
 
 from tr_bridge.config import InstanceConfig
+from tr_bridge.errors import DomainError
 
 logger = logging.getLogger(__name__)
 
@@ -35,28 +36,52 @@ class SessionState(StrEnum):
     failed = "failed"
 
 
-class LoginInProgressError(Exception):
+class LoginInProgressError(DomainError):
     """Raised when a login is initiated while one is already in progress."""
 
+    status = 409
+    code = "login_in_progress"
+    title = "Login already in progress"
 
-class CodeRejectedError(Exception):
+
+class CodeRejectedError(DomainError):
     """Raised when a submitted 2FA code is rejected by Trade Republic."""
 
+    status = 401
+    code = "code_rejected"
+    title = "2FA code rejected"
 
-class RateLimitedError(Exception):
+
+class RateLimitedError(DomainError):
     """Raised when Trade Republic rejects a login with HTTP 429 (rate limit)."""
 
+    status = 429
+    code = "rate_limited"
+    title = "Rate limited"
 
-class TrUpstreamError(Exception):
+
+class TrUpstreamError(DomainError):
     """Raised when a Trade Republic request fails with an unexpected upstream error."""
 
+    status = 502
+    code = "tr_upstream_error"
+    title = "Trade Republic upstream error"
 
-class SessionExpiredError(Exception):
+
+class SessionExpiredError(DomainError):
     """Raised when a timeline is requested but no valid session is available."""
 
+    status = 401
+    code = "session_expired"
+    title = "Session expired"
 
-class InvalidStateError(Exception):
+
+class InvalidStateError(DomainError):
     """Raised when an operation is attempted in an incompatible state."""
+
+    status = 409
+    code = "invalid_state"
+    title = "Operation not valid in current state"
 
     def __init__(self, state: SessionState) -> None:
         super().__init__(f"Operation not valid in state {state.value!r}")
@@ -65,6 +90,13 @@ class InvalidStateError(Exception):
 
 class NoLoginPendingError(InvalidStateError):
     """Raised when a 2FA code is submitted but no login is awaiting a code."""
+
+    code = "no_login_pending"
+    title = "No login pending"
+
+    @property
+    def detail(self) -> str:
+        return "No login is awaiting a 2FA code; start a login first."
 
 
 class InstanceSession:


### PR DESCRIPTION
Closes #19