### PR TITLE
Redirect root path (/) to the Swagger UI (/docs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,3 +104,13 @@ the urge to do so, the code design is wrong; fix the design instead.
 - Run `ruff format .` — no unformatted code may be left.
 - Run `ruff check .` — no warnings.
 - Ensure all new code has tests and coverage stays at or above 97%.
+
+---
+
+## Local smoke tests
+
+- Never touch the developer's local `data/` directory. It may hold a real `config.yml` and live
+  `tr_session_*` folders; deleting or overwriting it is destructive.
+- When a manual/live smoke test needs a config file, create it in a throwaway temp directory outside
+  the repo (e.g. under `/var/folders/.../opencode/`) and point `TR_CONFIG_PATH` at it. Clean up that
+  temp directory afterwards — never run `rm -rf data` or otherwise clobber the repo's `data/`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -292,10 +292,10 @@ Rationale:
 ## Authentication model
 
 All data endpoints require an `X-API-Key` header validated against the `api_key`
-field in `/data/config.yml`. Only the liveness probe (`GET /health`) and the public documentation
-endpoints (`/openapi.json`, `/docs`, `/redoc`) are reachable without it. The bridge is intended for
-intranet/private deployment; API-key auth is sufficient for that threat model and avoids the overhead
-of OAuth or mTLS.
+field in `/data/config.yml`. Only the base URL (`GET /`, which redirects to `/docs`), the liveness
+probe (`GET /health`) and the public documentation endpoints (`/openapi.json`, `/docs`, `/redoc`) are
+reachable without it. The bridge is intended for intranet/private deployment; API-key auth is
+sufficient for that threat model and avoids the overhead of OAuth or mTLS.
 
 The OpenAPI schema and the doc UIs (`/openapi.json`, `/docs`, `/redoc`) are intentionally public and
 listed in the middleware's `_PUBLIC_PATHS` alongside `/health`. Hiding the schema would be security

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ TR_CONFIG_PATH=/path/to/config.yml make run
 > `ConfigError`. Create it first (see [Configuration](#configuration)).
 
 Interactive API docs are public: Swagger UI at `/docs`, ReDoc at `/redoc`, and the
-raw schema at `/openapi.json`. They require no API key — access control is the
-`X-API-Key` header on the data endpoints, and the schema contains no secrets. The
-schema is also handy for importing a collection into Postman/Insomnia.
+raw schema at `/openapi.json`. The base URL (`/`) redirects to the Swagger UI, so
+opening `http://127.0.0.1:8000/` lands directly on the docs. They require no API
+key — access control is the `X-API-Key` header on the data endpoints, and the
+schema contains no secrets. The schema is also handy for importing a collection
+into Postman/Insomnia.
 
 ---
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -276,6 +276,23 @@ class TestAuthMiddleware:
 class TestOpenApiDocs:
     """The OpenAPI schema and doc UIs are public (no API key required)."""
 
+    def test_root_redirects_to_docs_without_api_key(self) -> None:
+        with patch("tr_bridge.main.Config") as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = MagicMock()
+            with TestClient(app, follow_redirects=False) as client:
+                resp = client.get("/")
+
+        assert resp.status_code in (307, 308)
+        assert resp.headers["location"] == "/docs"
+
+    def test_root_is_not_in_schema(self) -> None:
+        with patch("tr_bridge.main.Config") as mock_cfg_cls:
+            mock_cfg_cls.load.return_value = MagicMock()
+            with TestClient(app) as client:
+                schema = client.get("/openapi.json").json()
+
+        assert "/" not in schema["paths"]
+
     def test_openapi_json_is_public_and_lists_all_routes(self) -> None:
         with patch("tr_bridge.main.Config") as mock_cfg_cls:
             mock_cfg_cls.load.return_value = MagicMock()

--- a/tr_bridge/adapters/web/handlers.py
+++ b/tr_bridge/adapters/web/handlers.py
@@ -23,12 +23,14 @@ from tr_bridge.errors import DomainError, ProblemDetail, problem_response
 
 logger = logging.getLogger(__name__)
 
-# Paths that bypass API-key authentication: the liveness probe and the public
-# OpenAPI schema / documentation UIs (the schema carries no secrets). The
-# Swagger UI's oauth2-redirect subpath is whitelisted explicitly rather than via
-# a prefix, to avoid accidentally exposing unrelated ``/docs*`` routes.
+# Paths that bypass API-key authentication: the liveness probe, the base URL
+# (which redirects to the docs) and the public OpenAPI schema / documentation
+# UIs (the schema carries no secrets). The Swagger UI's oauth2-redirect subpath
+# is whitelisted explicitly rather than via a prefix, to avoid accidentally
+# exposing unrelated ``/docs*`` routes.
 _PUBLIC_PATHS: frozenset[str] = frozenset(
     {
+        "/",
         "/health",
         "/openapi.json",
         "/docs",

--- a/tr_bridge/adapters/web/routes.py
+++ b/tr_bridge/adapters/web/routes.py
@@ -5,9 +5,10 @@ delegate to the use case (via the per-instance :class:`InstanceRegistry`).
 Business orchestration and pytr access live behind the application and secondary
 adapter layers respectively.
 
-Every route defined here is protected: the auth middleware registered by
+Most routes defined here are protected: the auth middleware registered by
 ``register_handlers`` enforces ``X-API-Key`` for any path not in the public set.
-``/health`` is the sole public exception.
+The public exceptions are the base URL (``GET /``, which redirects to ``/docs``),
+the ``/health`` liveness probe, and the documentation endpoints.
 """
 
 from __future__ import annotations

--- a/tr_bridge/adapters/web/routes.py
+++ b/tr_bridge/adapters/web/routes.py
@@ -17,6 +17,7 @@ import sys
 from collections.abc import Callable
 
 from fastapi import FastAPI, Request
+from fastapi.responses import RedirectResponse
 
 from tr_bridge.adapters.web.schemas import (
     DependenciesModel,
@@ -38,6 +39,11 @@ def register_routes(app: FastAPI, *, read_version: Callable[[], str]) -> None:
     ``read_version`` is injected by the composition root so the health route can
     report the running service version without this module owning that concern.
     """
+
+    @app.get("/", include_in_schema=False)
+    async def root() -> RedirectResponse:
+        """Redirect the base URL to the Swagger UI for a friendly landing page."""
+        return RedirectResponse(url="/docs")
 
     @app.get("/health", tags=["ops"])
     async def health() -> HealthResponse:


### PR DESCRIPTION
Closes #37